### PR TITLE
messing with kapacitor-unit

### DIFF
--- a/gtikk-charts/kapacitor/TICKscripts/stream/container_status_tester.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/container_status_tester.tick
@@ -1,0 +1,18 @@
+//dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.database('telegraf')
+		.retentionPolicy('autogen')
+		.measurement('docker_container_status')
+		.groupBy('container_name')
+	//|window()
+		//.period(1m)
+		//.every(1m)
+	|alert()
+		.warn(lambda: "container_status" != 'running')
+		.message('Docker Container {{index .Tags "container_name" }} is not running')
+		//.slack()
+		.stateChangesOnly()
+
+	

--- a/gtikk-charts/kapacitor/TICKscripts/stream/failed_pod_alert_tester.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/failed_pod_alert_tester.tick
@@ -1,0 +1,16 @@
+var data = stream 
+	| from()
+		.database('telegraf')
+		.retentionPolicy('autogen')
+		.measurement('kube_pod_status_phase')
+		.groupBy('pod')
+	//|window()
+		//.period(1m)
+		//.every(1m)
+data
+	|alert().id('temp')
+		.message('warning: Pod {{ index .Tags "pod"}} is not running')
+		.warn(lambda: "phase" == 'Failed' AND "gauge" == int(1))
+		.stateChangesOnly()
+		.slack()
+ 

--- a/gtikk-charts/kapacitor/TICKscripts/stream/slack_test_tester.tick
+++ b/gtikk-charts/kapacitor/TICKscripts/stream/slack_test_tester.tick
@@ -1,0 +1,15 @@
+//dbrp "telegraf"."autogen"
+
+stream
+	|from()
+		.database('telegraf')
+		.retentionPolicy('autogen')
+		.measurement('cpu')
+
+	|alert().id('cpu')
+		.message('cpu test')
+		.warn(lambda: int("usage_idle") < 100)
+		//.crit(lambda: 1 == 1)
+		//.slack()
+		//.iconEmoji(':exclamation:')
+	

--- a/gtikk-charts/kapacitor/TICKscripts/tests/all_tests.yaml
+++ b/gtikk-charts/kapacitor/TICKscripts/tests/all_tests.yaml
@@ -3,13 +3,13 @@ tests:
   # container_status.tick triggers no warning alert when the measurement 
   # container_status in the dbrp telegraf:autogen is running
   - name: "Alert Container Status:: No warning when running"  
-    task_name: container_status.tick
+    task_name: container_status_tester.tick
     db: telegraf
     rp: autogen
     type: stream
     data:
-      - docker_container_status,container_name=somename time=1542658000000000000 container_status=running
-      - docker_container_status,container_name=somename time=1542658730000000000 container_status=running
+      - docker_container_status container_name=somename time=1542658000000000000 container_status=running
+      - docker_container_status container_name=somename time=1542658730000000000 container_status=running
     expects:
       ok: 0
       warn: 0
@@ -18,13 +18,13 @@ tests:
   # container_status.tick triggers a warning alert when the measurement 
   # container_status in the dbrp telegraf:autogen is not running
   - name: "Alert Container Status:: Warning when not running"  
-    task_name: container_status.tick
+    task_name: container_status_tester.tick
     db: telegraf
     rp: autogen
     type: stream
     data:
-      - docker_container_status,container_name=somename time=1542658000000000000 container_status=running
-      - docker_container_status,container_name=somename time=1542658730000000000 container_status=error  
+      - docker_container_status container_status="running"
+      - docker_container_status container_status="error"
     expects:
       ok: 0
       warn: 1
@@ -32,39 +32,35 @@ tests:
 
       
 #pod tests      
-  - name: "Slack Alert:: on failed Pod test"
-    task_name: failed_pod_alert.tick
+  - name: "Alert Slack:: pod alert test"  
+    task_name: failed_pod_alert_tester.tick
     db: telegraf
     rp: autogen
     type: stream
-    data: 
-    - kube_pod_status_phase,pod=db time=1542658000000000000 gauge=0 phase='Failed'
-    - kube_pod_status_phase,pod=db time=1542658730000000000 gauge=1 phase='Failed'
-    
+    data:
+      - kube_pod_status_phase,phase=Failed gauge=1 
+      - kube_pod_status_phase,phase=Failed gauge=1 
     expects:
       ok: 0
       warn: 1
       crit: 0
 
+
 #slack test
   - name: "Alert Slack:: Usage critical when idle < 100%, lol"
-    task_name: slack_alert.tick
+    task_name: slack_test_tester.tick
     db: telegraf
     rp: autogen
     type: stream
     data:
-    - cpu,usage_idle=5
+    - cpu usage_idle=10
+    - cpu usage_idle=10
+    - cpu usage_idle=10
     expects:
       ok: 0
-      warn: 1
+      warn: 3
       crit: 0
-      
-      
-      
-      
-      
-      
-      
+
 #example test cases
   # alert_weather.tick triggers a critical alert when the measurement 
   # temperature in the dbrp weather:default is bigger than 80
@@ -108,5 +104,7 @@ tests:
     expects:
       ok: 0
       warn: 1
-      crit: 0      
-          
+      crit: 0
+
+
+       


### PR DESCRIPTION
adding test versions of alerts, unit tests working (sorta), I had to rewrite/reverse engineer the pod status alert in order to get it to work with the testing framework. So the code is different but the logic for the warnings are the same so it should be ok. 

If we want to discuss going this route with kapa-unit then I can make some more test files. (also probably need to put them in a different folder). like keep the actual alerts in the alerts folder and then make a folder labeled test_versions for the files that we will be running tests on. 