### PR TITLE
Remove unused Grafana Sidecar Pods

### DIFF
--- a/charts/grafana/values.yaml
+++ b/charts/grafana/values.yaml
@@ -292,12 +292,12 @@ sidecar:
 #     cpu: 50m
 #     memory: 50Mi
   dashboards:
-    enabled: true
+    enabled: false
     # label that the configmaps with dashboards are marked with
     label: grafana_dashboard
     # folder in the pod that should hold the collected dashboards
     folder: /tmp/dashboards
   datasources:
-    enabled: true
+    enabled: false
     # label that the configmaps with datasources are marked with
     label: grafana_datasource


### PR DESCRIPTION
This PR removes the Grafana Sidecar Pods that are created and not used by the methods which set up data-sources and dashboards.